### PR TITLE
Fix for Firefox, dependencies, installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,37 @@
 # Grav HAX Plugin
 
-HAX is a [Grav](http://github.com/getgrav/grav) plugin that can be used to get the HAX editor integrated into your Grav site with ease. Simply run from inside the hax plugin directory
+HAX is a [Grav](http://github.com/getgrav/grav) plugin that can be used to get the HAX editor integrated into your Grav site with ease.
 
-# Installation
+## Installation
 
-## GPM Installation (Preferred)
+### GPM Installation (Preferred)
 
 The simplest way to install this plugin is via the [Grav Package Manager (GPM)](http://learn.getgrav.org/advanced/grav-gpm).  From the root of your Grav install type:
 
-    bin/gpm install webcomponents
     bin/gpm install hax
 
-## Manual Installation
+### Manual Installation
 
 If for some reason you can't use GPM you can manually install this plugin. Download the zip version of this repository and unzip it under `GRAV-INSTALL-ROOT/user/plugins`. Then, rename the folder to `hax`.
 
 You should now have all the plugin files under:
 
-	GRAV-INSTALL-ROOT/user/plugins/hax
+    GRAV-INSTALL-ROOT/user/plugins/hax
 
-Also note that if you do this method you will need to install the webcomponents plugin as well.
+Also note that if you do this method you will need to install the [webcomponents](https://github.com/elmsln/grav-plugin-webcomponents) plugin as well.
 
-# Simple Usage
+## Simple Usage
 
-Create this folder if it doesn't exist yet: `GRAV-INSTALL-ROOT/user/webcomponents`. Copy `GRAV-INSTALL-ROOT/user/plugins/hax/bower.json` to `GRAV-INSTALL-ROOT/user/webcomponents/bower.json`. Then go to `GRAV-INSTALL-ROOT/user/webcomponents` and run `bower install`. Answer any questions about dependencies that it has (we try to auto select these as best we can).
+Create this folder if it doesn't exist yet: `GRAV-INSTALL-ROOT/user/data/webcomponents`. Copy `GRAV-INSTALL-ROOT/user/plugins/hax/bower.json` to `GRAV-INSTALL-ROOT/user/data/webcomponents/bower.json`. Then go to `GRAV-INSTALL-ROOT/user/webcomponents` and run `bower install LRNWebComponents/wysiwyg-hax`. Answer any questions about dependencies that it has (we try to auto select these as best we can).
 
-## Configuration
+### Configuration
 
-Important note: HAX generates HTML and while Grav can handle HTML, it's Markdown parser can get angry about HTML tags + no endlines. As HAX tries to generate markup automatically it can get mad and it will appear that content disappears, however this is the Markdown parser conflicting with HTML. Disable markdown processing on posts that you use HAX with and it should be fine.
+Important note: HAX generates HTML, and while Grav can handle HTML, it's Markdown parser can get angry about HTML tags + no endlines. As HAX tries to generate markup automatically, it can get mad and it will appear that content disappears, however this is the Markdown parser conflicting with HTML. Disable markdown processing on posts that you use HAX with, and it should be fine.
 
-HAX is **enabled** by default.  You can change this behavior by setting `enasbled: false` in the plugin's configuration.  Simply copy the `user/plugins/hax/hax.yaml` into `user/config/plugins/hax.yaml` and make your modifications. There is also a variable to adjust positioning of the hax context menus based on theme interference as well as what elements to auto-load (or attempt to) during spin up.
+HAX is **enabled** by default.  You can change this behavior by setting `enabled: false` in the plugin's configuration.  Simply copy the `user/plugins/hax/hax.yaml` into `user/config/plugins/hax.yaml` and make your modifications. There is also a variable to adjust positioning of the hax context menus based on theme interference as well as what elements to auto-load (or attempt to) during spin up.
 
-```
+
+```yaml
 enabled: true                       # enabled by default
 autoload_element_list: 'video-player wikipedia-query pdf-element lrn-table media-image'                        # a sample list of elements to expose. these will be removed as HAX matures and be optional / pointed to as far as what's compatible
 offset_left: 0                  # theme compatibility if it's goofed up

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -11,6 +11,11 @@ keywords: webcomponents,hax,polymer,plugin
 bugs: https://github.com/elmsln/grav-plugin-hax/issues
 license: Apache 2.0
 
+dependencies:
+  - admin
+  - atools
+  - webcomponents
+
 form:
   validation: strict
   fields:

--- a/hax.php
+++ b/hax.php
@@ -123,7 +123,7 @@ class HAXPlugin extends Plugin {
    * Simple HTML Import render.
    */
   public function createHTMLImport($path, $rel = 'import') {
-    return '<link rel="' . $rel . '" href="' . $path . '" />';
+    return '<link rel="' . $rel . '" href="' . $path . '">';
   }
 
   /**

--- a/hax.php
+++ b/hax.php
@@ -10,6 +10,7 @@ use RocketTheme\Toolbox\Event\Event;
 use RocketTheme\Toolbox\File\File;
 use Symfony\Component\Yaml\Yaml;
 use Grav\Plugin\AtoolsPlugin;
+use Grav\Plugin\WebcomponentsPlugin;
 
 define('HAX_DEFAULT_OFFSET', 0);
 define('HAX_DEFAULT_ELEMENTS', 'video-player wikipedia-query pdf-element lrn-table media-image');
@@ -21,11 +22,11 @@ class HAXPlugin extends Plugin {
   public function onPluginsInitialized() {
       // Verify installation files.
       if (!($this->verifyWebcomponentsInstallation())){
-        dump('failed to verify');
         return;
       }
 
-    if($this->isAdmin()) {
+    // Only use HAX if in normal admin mode, not expert mode.
+    if($this->isAdmin() && ($this->grav['uri']->param("mode") != "expert")) {
       $this->grav['locator']->addPath('blueprints', '', __DIR__ . DS . 'blueprints');
       $this->enable(['onTwigTemplatePaths' => ['onTwigTemplatePaths', 999]]);
     }
@@ -41,7 +42,7 @@ class HAXPlugin extends Plugin {
       // discover and autoload our components
       $assets = $this->grav['assets'];
       // Webcomponents plugin doesn't include the polyfill for admin editing pages. Adding it here.
-      $assets->addJS($this->getBaseURL() . 'bower_components/webcomponentsjs/webcomponents-lite.min.js', array('priority' => 1000, 'group' => 'head'));
+      $assets->addJS($this->getBaseURL() . 'bower_components/webcomponentsjs/' . WebcomponentsPlugin::polyfillLibrary(), array('priority' => 1000, 'group' => 'head'));
       $file = $this->getBaseURL() . 'bower_components/wysiwyg-hax/wysiwyg-hax.html';
       $imports = $this->createHTMLImport($file) . "\n";
       // build the inline import
@@ -1068,7 +1069,7 @@ class HAXPlugin extends Plugin {
 
       $grav = new Grav();
       $required_files = array(
-          $this->webcomponentsDir() . 'bower_components/webcomponentsjs/webcomponents-lite.min.js',
+          $this->webcomponentsDir() . 'bower_components/webcomponentsjs/' . WebcomponentsPlugin::polyfillLibrary(),
           $this->webcomponentsDir() . 'bower_components/wysiwyg-hax/wysiwyg-hax.html',
       );
 

--- a/hax.php
+++ b/hax.php
@@ -98,7 +98,7 @@ class HAXPlugin extends Plugin {
    * @return string  The base path to the user / webcomponents directory
    */
   public function getBaseURL() {
-    return $this->grav['base_url'] . '/user/webcomponents/';
+    return $this->grav['base_url'] . '/user/data/webcomponents/';
   }
 
   /**
@@ -106,7 +106,7 @@ class HAXPlugin extends Plugin {
    * @return string  The base path to the user / webcomponents directory
    */
   public function webcomponentsDir() {
-    return getcwd() . '/user/webcomponents/';
+    return getcwd() . '/user/data/webcomponents/';
   }
   /**
    * Simple HTML Import render.


### PR DESCRIPTION
I did create a new plugin (non-live on the gpm as of writing this) to assist with disabling HAX if certain files are missing (atools).  You may wish to hold off merging until that's live.

